### PR TITLE
engrammerdvp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [Arno's Engram]: https://engram.dev
 
 # Realengrammer - [Engrammer] layout for programmers.
-This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by the Real Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an Engram layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout!
+This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by both the original programmers dvorak the Real Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an Engram layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout! 
 
  This layouts features are:
 * Like Engrammer, / is placed by the right index finger to make typing directories and navigating the shell as easy as possible.
@@ -11,7 +11,7 @@ This is a programmer-friendly variant of Engrammer which itself is a variant of 
 
 * Semicolon is placed relative to comma and period just like Engrammer.
 
-* Numbers are placed in an even odd order so that 1 and 0, the most used numbers, are handled by the indexes. 
+* Numbers are placed in an different order so that 1 and 0, the most used numbers, are handled by the indexes. 
 
 * In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
 To illustrate the differences between this layout, Engrammer, and Engram:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is a programmer-friendly variant of Engrammer which itself is a variant of 
 * Commonly used math symbols like +, -, /, <, >, and = are centered on the index fingers and not the pinkies.
 * [], {}, and () are placed to corresponde the ring, middle, and index finger pairs respectively making it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and the like.
 
-* Semicolon is placed relative to comma and period just like standard.
-* 
+* Semicolon is placed relative to comma and period just like Engrammer.
+
 * In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
 To illustrate the differences between this layout, Engrammer, and Engram:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This is a programmer-friendly variant of Engrammer which itself is a variant of 
 * Semicolon is placed relative to comma and period just like standard.
 * This sub-layout makes it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and alikes by incorporating the symbol layout Programmer Dvorak. It was generated through reflection of the most common constructs in these languages and the rules set forward by the August Dvorak in his research, then verified by scanning through thousands of source code lines ensuring that a good fit was found.
 * In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
-To illustrate the differences between this layout, Engrammer, Engram, and QWERTY:
+To illustrate the differences between this layout, Engrammer, and Engram:
 
-Engrammerdvp
+Realengrammer
 >     $~ &% [7 {5 (3  +1  =9  )0 }2 ]4 *6 !8 #`
 >        bB yY oO uU  '"  ;:  lL dD wW vV zZ @^ \|
 >        cC iI eE aA  ,<  .>  hH tT sS nN qQ

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by the Real Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an Engram layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout!
 
  This layouts features are:
- 
+* Like Engrammer, / is placed by the right index finger to make typing directories and navigating the shell as easy as possible.
+* Commonly used math symbols like +, -, /, <, >, and = are centered on the index fingers and not the pinkies.
+* [], {}, and () are placed to corresponde the ring, middle, and index finger pairs respectively making it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and the like.
+
 * Semicolon is placed relative to comma and period just like standard.
-* This sub-layout makes it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and alikes by incorporating the symbol layout Programmer Dvorak. It was generated through reflection of the most common constructs in these languages and the rules set forward by the August Dvorak in his research, then verified by scanning through thousands of source code lines ensuring that a good fit was found.
+* 
 * In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
 To illustrate the differences between this layout, Engrammer, and Engram:
 
@@ -28,11 +31,6 @@ Engram
 >        cC iI eE aA  ,;  .:  hH tT sS nN qQ 
 >        gG xX jJ kK  -_  ?!  rR mM fF pP
 
-
-
-
-
-
 ## Linux setup
 
 Install:
@@ -43,7 +41,7 @@ Install:
 
 Activate:
 
-    setxkbmap -layout us    -variant engrammer 
+    setxkbmap -layout us    -variant realengrammer ctrl:swapcaps 
 
 Repair (e.g. whenever a system-wide XKB package upgrade reverts installation):
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [Arno's Engram]: https://engram.dev
 
-# Engrammerdvp - [Engrammer] layout for programmers.
-This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by the Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an en layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout!
+# Realengrammer - [Engrammer] layout for programmers.
+This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by the Real Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an Engram layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout!
+
+ This layouts features are:
  
 * Semicolon is placed relative to comma and period just like standard.
 * This sub-layout makes it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and alikes by incorporating the symbol layout Programmer Dvorak. It was generated through reflection of the most common constructs in these languages and the rules set forward by the August Dvorak in his research, then verified by scanning through thousands of source code lines ensuring that a good fit was found.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ This is a programmer-friendly variant of Engrammer which itself is a variant of 
  This layouts features are:
 * Like Engrammer, / is placed by the right index finger to make typing directories and navigating the shell as easy as possible.
 * Commonly used math symbols like +, -, /, <, >, and = are centered on the index fingers and not the pinkies.
+
 * [], {}, and () are placed to corresponde the ring, middle, and index finger pairs respectively making it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and the like.
 
 * Semicolon is placed relative to comma and period just like Engrammer.
+
+* Numbers are placed in an even odd order so that 1 and 0, the most used numbers, are handled by the indexes. 
 
 * In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
 To illustrate the differences between this layout, Engrammer, and Engram:

--- a/README.md
+++ b/README.md
@@ -1,37 +1,35 @@
 [Arno's Engram]: https://engram.dev
 
-# Engrammer - [Arno's Engram] layout for programmers
-
-This is a programmer-friendly variant of [Arno's Engram] 2.0 keyboard
-layout that helps maintain cross-proficiency with standard keyboards:
-
-* Shifted pairs are standard (e.g. quotes don't shift to parentheses).
+# Engrammerdvp - [Engrammer] layout for programmers.
+This is a programmer-friendly variant of Engrammer which itself is a variant of [Arno's Engram] 2.0 keyboard layout that helps speed up programming by putting the symbols in a better position inspired by the Programmer Dvorak layout. Why a new layout? As nice as it is, engrammer has some serious problems when writing source code. The characters are in an en layout all right, but the symbols are put in the same hopeless locations as in the Qwerty layout!
+ 
 * Semicolon is placed relative to comma and period just like standard.
-* Equals and square brackets are placed near their standard locations.
+* This sub-layout makes it easier to write source code in C, C#, Java, Pascal, Lisp, CSS, XML and alikes by incorporating the symbol layout Programmer Dvorak. It was generated through reflection of the most common constructs in these languages and the rules set forward by the August Dvorak in his research, then verified by scanning through thousands of source code lines ensuring that a good fit was found.
+* In contrast to engrammer, this layout does not attempt to preserve application shortcuts that assume standard shifted pairs, such as Control-Equals for the "zoom in" operation. It instead focuses solely on increasing speed when typing source. 
+To illustrate the differences between this layout, Engrammer, Engram, and QWERTY:
 
-In addition, application shortcuts that assume standard shifted pairs,
-such as Control-Equals for the "zoom in" operation, now work properly.
+Engrammerdvp
+>     $~ &% [7 {5 (3  +1  =9  )0 }2 ]4 *6 !8 #`
+>        bB yY oO uU  '"  ;:  lL dD wW vV zZ @^ \|
+>        cC iI eE aA  ,<  .>  hH tT sS nN qQ
+>        gG xX jJ kK  -_  /?  rR mM fF pP
 
-To illustrate the differences between this layout, Engram, and QWERTY:
-
->*Legend:* Gold is [Arno's Engram]; Blue is Engram-like; Pink is new.
->![Rendering of this layout on a standard 60% keyboard.](https://raw.githubusercontent.com/sunaku/engrammer/main/layout.png)
->![Rendering of this layout on an ortholinear keyboard.](https://raw.githubusercontent.com/sunaku/engrammer/main/ortho.png)
->
+Engrammer
 >     `~ 1! 2@ 3# 4$  5%  6^  7& 8* 9( 0) [{ ]}
 >        bB yY oO uU  '"  ;:  lL dD wW vV zZ =+ \|
 >        cC iI eE aA  ,<  .>  hH tT sS nN qQ
 >        gG xX jJ kK  -_  /?  rR mM fF pP
 
-For example, here are my split ortholinear keyboards using this layout:
+Engram     
+>     [{ 1| 2= 3~ 4+  5<  6>  7^ 8& 9% 0* ]} /\
+>        bB yY oO uU  '(  ")  lL dD wW vV zZ #$ @`
+>        cC iI eE aA  ,;  .:  hH tT sS nN qQ 
+>        gG xX jJ kK  -_  ?!  rR mM fF pP
 
-* This is [my Glove80](https://sunaku.github.io/moergo-glove80-keyboard.html) keyboard by MoErgo:
->![Photo of MoErgo Glove80](https://raw.githubusercontent.com/sunaku/sunaku.github.io/master/moergo-glove80-keyboard-photograph.jpg)
->![Layout of MoErgo Glove80](https://raw.githubusercontent.com/sunaku/sunaku.github.io/master/moergo-glove80-keyboard-base-layer.png)
 
-* This is [my Remnant](https://sunaku.github.io/ergohaven-remnant-keyboard.html) keyboard by Ergohaven:
->![Photo of Ergohaven Remnant](https://raw.githubusercontent.com/sunaku/sunaku.github.io/master/ergohaven-remnant-keyboard-photograph.jpg)
->![Layout of Ergohaven Remnant](https://raw.githubusercontent.com/sunaku/sunaku.github.io/master/ergohaven-remnant-keyboard-base-layer.png)
+
+
+
 
 ## Linux setup
 
@@ -43,8 +41,7 @@ Install:
 
 Activate:
 
-    setxkbmap -layout us    -variant engrammer         # one layout; no switch
-    setxkbmap -layout us,us -variant engrammer,basic   # dual layout switching
+    setxkbmap -layout us    -variant engrammer 
 
 Repair (e.g. whenever a system-wide XKB package upgrade reverts installation):
 
@@ -58,21 +55,6 @@ Uninstall:
     sudo make uninstall
     echo Now restart your graphical session.
 
-## Windows setup
-
-You can [download a pre-built installation package](
-  https://github.com/sunaku/engrammer/releases/download/windows/engrammer.zip
-) or build one yourself, like this:
-
-1. Install the official _Microsoft Keyboard Layout Creator_ app: [MSKLC version 1.4](
-  https://www.microsoft.com/en-us/download/details.aspx?id=102134
-).
-
-2. Launch the MSKLC app and open up the `windows\engrammer.klc` source file.
-
-3. From the "Project" menu, select the "Build DLL and Setup Package" action.
-
-4. Open the resulting build directory and run the `setup.exe` installer file.
 
 ## License
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -10,7 +10,7 @@ install: $(SOURCE_SYMBOLS) $(TARGET_SYMBOLS) $(SOURCE_RULES) $(TARGET_RULES)
 	sed -i "$$(awk '/variantList/{ print NR; exit }' $(TARGET_RULES)) r $(SOURCE_RULES)" $(TARGET_RULES)
 
 uninstall: $(TARGET_SYMBOLS) $(TARGET_RULES)
-	sed -i '/ ENGRAMMERDVP BEGIN /,/ ENGRAMMERDVP END /d' $^
+	sed -i '/ REALENGRAMMER BEGIN /,/ REALENGRAMMER END /d' $^
 
 reinstall:
 	$(MAKE) uninstall

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -10,7 +10,7 @@ install: $(SOURCE_SYMBOLS) $(TARGET_SYMBOLS) $(SOURCE_RULES) $(TARGET_RULES)
 	sed -i "$$(awk '/variantList/{ print NR; exit }' $(TARGET_RULES)) r $(SOURCE_RULES)" $(TARGET_RULES)
 
 uninstall: $(TARGET_SYMBOLS) $(TARGET_RULES)
-	sed -i '/ ENGRAMMER BEGIN /,/ ENGRAMMER END /d' $^
+	sed -i '/ ENGRAMMERDVP BEGIN /,/ ENGRAMMERDVP END /d' $^
 
 reinstall:
 	$(MAKE) uninstall

--- a/linux/usr-share-X11-xkb-rules-evdev
+++ b/linux/usr-share-X11-xkb-rules-evdev
@@ -1,8 +1,8 @@
-<!-- ENGRAMMER BEGIN -->
+<!-- ENGRAMMERDVP BEGIN -->
 <variant>
   <configItem>
-    <name>engrammer</name>
-    <description>English (Engrammer)</description>
+    <name>engrammerdvp</name>
+    <description>English (Engrammerdvp)</description>
   </configItem>
 </variant>
-<!-- ENGRAMMER END -->
+<!-- ENGRAMMERDVP END -->

--- a/linux/usr-share-X11-xkb-rules-evdev
+++ b/linux/usr-share-X11-xkb-rules-evdev
@@ -1,8 +1,8 @@
-<!-- ENGRAMMERDVP BEGIN -->
+<!-- REALENGRAMMER BEGIN -->
 <variant>
   <configItem>
-    <name>engrammerdvp</name>
-    <description>English (Engrammerdvp)</description>
+    <name>realengrammer</name>
+    <description>English (Realengrammer)</description>
   </configItem>
 </variant>
-<!-- ENGRAMMERDVP END -->
+<!-- REALENGRAMMER END -->

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -1,31 +1,31 @@
-// ENGRAMMER BEGIN ////////////////////////////////////////
+// ENGRAMMERDVP BEGIN ////////////////////////////////////////
 //
-// Engrammer - Arno's Engram 2.0 https://engram.dev variant
-//             with standard shifted pairs, for programmers
+// Engrammerdvp - Engrammer variant with Programmer's Dvorak sublayout
 //
-//	`~ 1! 2@ 3# 4$  5%  6^  7& 8* 9( 0) [{ ]}
-//	   bB yY oO uU  '"  ;:  lL dD wW vV zZ =+ \|
+//	$~ &% [7 {5 }3  (1  =9  *0 )2 +4 ]6 !8 #`
+//	   bB yY oO uU  '"  ;:  lL dD wW vV zZ @^ \|
 //	   cC iI eE aA  ,<  .>  hH tT sS nN qQ
 //	   gG xX jJ kK  -_  /?  rR mM fF pP
 //
 partial alphanumeric_keys
-xkb_symbols "engrammer"
-{
+xkb_symbols "engrammerdvp" {
 	include "us(basic)"
 
-	key <TLDE> { [        grave,  asciitilde ] }; // `~
-	key <AE01> { [            1,      exclam ] }; // 1!
-	key <AE02> { [            2,          at ] }; // 2@
-	key <AE03> { [            3,  numbersign ] }; // 3#
-	key <AE04> { [            4,      dollar ] }; // 4$
-	key <AE05> { [            5,     percent ] }; // 5%
-	key <AE06> { [            6,  asciicircum] }; // 6^
-	key <AE07> { [            7,   ampersand ] }; // 7&
-	key <AE08> { [            8,    asterisk ] }; // 8*
-	key <AE09> { [            9,   parenleft ] }; // 9(
-	key <AE10> { [            0,  parenright ] }; // 0)
-	key <AE11> { [  bracketleft,   braceleft ] }; // [{
-	key <AE12> { [ bracketright,  braceright ] }; // ]}
+	key <TLDE> { [ dollar,          asciitilde] }; //$~
+	key <AE01> { [ ampersand,       percent] }; //&%
+	key <AE02> { [ bracketleft,     7] }; // [7
+	key <AE03> { [ braceleft,       5] }; // {5
+	key <AE04> { [ braceright,      3] }; // }3
+	key <AE05> { [ parenleft,       1] }; // (1
+	key <AE06> { [ equal,           9] }; // =9
+
+	// symbols row, right side
+	key <AE07> { [ asterisk,        0] }; // *0	
+	key <AE08> { [ parenright,      2] }; // )2
+	key <AE09> { [ plus,            4] }; // +4
+	key <AE10> { [ bracketright,    6] }; // ]6
+	key <AE11> { [ exclam,          8] }; // !8
+	key <AE12> { [ numbersign,      grave] }; // #`
 
 	key <AD01> { [            b,           B ] }; // bB
 	key <AD02> { [            y,           Y ] }; // yY
@@ -38,7 +38,7 @@ xkb_symbols "engrammer"
 	key <AD09> { [            w,           W ] }; // wW
 	key <AD10> { [            v,           V ] }; // vV
 	key <AD11> { [            z,           Z ] }; // zZ
-	key <AD12> { [        equal,        plus ] }; // =+
+	key <AD12> { [           at,   asciicircum] }; // @
 	key <BKSL> { [    backslash,         bar ] }; // \|
 
 	key <AC01> { [            c,           C ] }; // cC
@@ -64,4 +64,4 @@ xkb_symbols "engrammer"
 	key <AB09> { [            f,           F ] }; // fF
 	key <AB10> { [            p,           P ] }; // pP
 };
-// ENGRAMMER END //////////////////////////////////////////
+// ENGRAMMERDVP END //////////////////////////////////////////

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -63,7 +63,7 @@ xkb_symbols "engrammerdvp" {
 	key <AB08> { [            m,           M ] }; // mM
 	key <AB09> { [            f,           F ] }; // fF
 	key <AB10> { [            p,           P ] }; // pP
-	key <CAPS> { [      Control_L             ] };
-	key <LCTL> {  [ CapsLock ] };
+	key <CAPS> { [ Control_L ] };
+	key <LCTL> { [ Caps_Lock ] };
 };
 // ENGRAMMERDVP END //////////////////////////////////////////

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -1,8 +1,8 @@
 // ENGRAMMERDVP BEGIN ////////////////////////////////////////
 //
-// Engrammerdvp - Engrammer variant with Programmer's Dvorak sublayout
+// Engrammerdvp - Engrammer variant with Real Programmer's Dvorak sublayout
 //
-//	$~ &% [7 {5 }3  (1  =9  *0 )2 +4 ]6 !8 #`
+//	$~ &% [7 {5 (3  +1  =9  )0 }2 ]4 *6 !8 #`
 //	   bB yY oO uU  '"  ;:  lL dD wW vV zZ @^ \|
 //	   cC iI eE aA  ,<  .>  hH tT sS nN qQ
 //	   gG xX jJ kK  -_  /?  rR mM fF pP
@@ -11,21 +11,21 @@ partial alphanumeric_keys
 xkb_symbols "engrammerdvp" {
 	include "us(basic)"
 
-	key <TLDE> { [ dollar,          asciitilde] }; //$~
-	key <AE01> { [ ampersand,       percent] }; //&%
-	key <AE02> { [ bracketleft,     7] }; // [7
-	key <AE03> { [ braceleft,       5] }; // {5
-	key <AE04> { [ braceright,      3] }; // }3
-	key <AE05> { [ parenleft,       1] }; // (1
-	key <AE06> { [ equal,           9] }; // =9
+	key <TLDE> { [ dollar,         asciitilde] }; // $~
+	key <AE01> { [ ampersand,         percent] }; // &%
+	key <AE02> { [ bracketleft,             7] }; // [7
+	key <AE03> { [ braceleft,               5] }; // {5
+	key <AE04> { [ parenleft,               3] }; // (3
+	key <AE05> { [ plus,                    1] }; // +1
+	key <AE06> { [ equal,                   9] }; // =9
 
 	// symbols row, right side
-	key <AE07> { [ asterisk,        0] }; // *0	
-	key <AE08> { [ parenright,      2] }; // )2
-	key <AE09> { [ plus,            4] }; // +4
-	key <AE10> { [ bracketright,    6] }; // ]6
-	key <AE11> { [ exclam,          8] }; // !8
-	key <AE12> { [ numbersign,      grave] }; // #`
+	key <AE07> { [ parenright,              0] }; // )0	
+	key <AE08> { [ braceright,              2] }; // }2
+	key <AE09> { [ bracketright,            4] }; // ]4
+	key <AE10> { [ asterisk,                6] }; // *6
+	key <AE11> { [ exclam,                  8] }; // !8
+	key <AE12> { [ numbersign,          grave] }; // #`
 
 	key <AD01> { [            b,           B ] }; // bB
 	key <AD02> { [            y,           Y ] }; // yY
@@ -38,7 +38,7 @@ xkb_symbols "engrammerdvp" {
 	key <AD09> { [            w,           W ] }; // wW
 	key <AD10> { [            v,           V ] }; // vV
 	key <AD11> { [            z,           Z ] }; // zZ
-	key <AD12> { [           at,   asciicircum] }; // @
+	key <AD12> { [           at,  asciicircum] }; // @^
 	key <BKSL> { [    backslash,         bar ] }; // \|
 
 	key <AC01> { [            c,           C ] }; // cC

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -65,5 +65,6 @@ xkb_symbols "engrammerdvp" {
 	key <AB10> { [            p,           P ] }; // pP
 	key <CAPS> { [ Control_L ] };
 	key <LCTL> { [ Caps_Lock ] };
+	modifier_map Control { <CAPS> };
 };
 // ENGRAMMERDVP END //////////////////////////////////////////

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -1,6 +1,6 @@
-// ENGRAMMERDVP BEGIN ////////////////////////////////////////
+// REALENGRAMMER BEGIN ////////////////////////////////////////
 //
-// Engrammerdvp - Engrammer variant with Real Programmer's Dvorak sublayout
+// Realengrammer - Engrammer variant with Real Programmer's Dvorak sublayout
 //
 //	$~ &% [7 {5 (3  +1  =9  )0 }2 ]4 *6 !8 #`
 //	   bB yY oO uU  '"  ;:  lL dD wW vV zZ @^ \|
@@ -8,7 +8,7 @@
 //	   gG xX jJ kK  -_  /?  rR mM fF pP
 //
 partial alphanumeric_keys
-xkb_symbols "engrammerdvp" {
+xkb_symbols "realengrammer" {
 	include "us(basic)"
 
 	key <TLDE> { [ dollar,         asciitilde] }; // $~
@@ -64,4 +64,4 @@ xkb_symbols "engrammerdvp" {
 	key <AB09> { [            f,           F ] }; // fF
 	key <AB10> { [            p,           P ] }; //
 };
-// ENGRAMMERDVP END //////////////////////////////////////////
+// REALENGRAMMER END //////////////////////////////////////////

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -62,9 +62,6 @@ xkb_symbols "engrammerdvp" {
 	key <AB07> { [            r,           R ] }; // rR
 	key <AB08> { [            m,           M ] }; // mM
 	key <AB09> { [            f,           F ] }; // fF
-	key <AB10> { [            p,           P ] }; // pP
-	key <CAPS> { [ Control_L ] };
-	key <LCTL> { [ Caps_Lock ] };
-	modifier_map Control { <CAPS> };
+	key <AB10> { [            p,           P ] }; //
 };
 // ENGRAMMERDVP END //////////////////////////////////////////

--- a/linux/usr-share-X11-xkb-symbols-us
+++ b/linux/usr-share-X11-xkb-symbols-us
@@ -63,5 +63,7 @@ xkb_symbols "engrammerdvp" {
 	key <AB08> { [            m,           M ] }; // mM
 	key <AB09> { [            f,           F ] }; // fF
 	key <AB10> { [            p,           P ] }; // pP
+	key <CAPS> { [      Control_L             ] };
+	key <LCTL> {  [ CapsLock ] };
 };
 // ENGRAMMERDVP END //////////////////////////////////////////


### PR DESCRIPTION
I am requesting that engrammer merge my updated layout that incorporates the symbol layout of programmers dvorak. There is no good reason for the top row to have the numbers on the top row without needing shift, you aren't hard coding those constants are you? The most used symbols while programming like { are now in much more reasonable spots. If this layout is meant for programmers, you should incorporate these changes. Keeping all the symbols in the same hopeless spots they are in on the qwerty keyboard just for the sake of preserving macros is a bad design choice frankly.